### PR TITLE
Use File.separator to make paths work on any OS

### DIFF
--- a/src/nervoussystem/obj/MeshExport.java
+++ b/src/nervoussystem/obj/MeshExport.java
@@ -274,7 +274,7 @@ public class MeshExport extends PGraphics {
 	
 	textureG.endDraw();
 	
-	texture.save(file.getParent()  + "\\" + filenameSimple + ".png");
+	texture.save(file.getParent() + File.separator + filenameSimple + ".png");
   }
   
   public void beginShape(int kind) {

--- a/src/nervoussystem/obj/OBJExport.java
+++ b/src/nervoussystem/obj/OBJExport.java
@@ -77,7 +77,7 @@ public class OBJExport extends MeshExport {
 		PrintWriter matWriter = null;
 		try {
 			String filepath = file.getParent();
-			matWriter = new PrintWriter(new FileWriter(new File(filepath + "\\" + filenameSimple + ".mtl")));
+			matWriter = new PrintWriter(new FileWriter(new File(filepath + File.separator + filenameSimple + ".mtl")));
 		  } 
 		  catch (IOException e) {
 			throw new RuntimeException(e);


### PR DESCRIPTION
With the previous approach the .mtl and .png files end up in the parent folder with a backslash in the middle of the file name (at least on my Linux machine).
